### PR TITLE
Remove dependencies on co, monk and mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ A simple Node.js script that finds the top X largest documents in a given MongoD
 
 * Scalable - can work with any collection size
 * Fast - utilizes [range-based pagination](https://docs.mongodb.com/manual/reference/method/cursor.skip/#cursor-skip) for fast table scanning
-* Easy - simply provide the MongoDB connection string and collection name
+* Easy - simply provide the MongoDB connection string and the db and collection names
 
 ## Preview
 
-![Preview](https://raw.github.com/eladnava/mongodb-largest-documents/master/assets/preview.png) 
+![Preview](https://raw.github.com/eladnava/mongodb-largest-documents/master/assets/preview.png)
 
 ## Requirements
 
 * A MongoDB database
-* Node.js v4.x+ for ES6 generators support
+* Node.js v8.x+ for async/await
 
 ## Usage
 
@@ -27,30 +27,25 @@ npm install mongodb-largest-documents --save
 Then, use the following code to find the top 100 largest documents in a given collection, modifying the `config` variable accordingly:
 
 ```js
-var mongodbLargestDocuments = require('mongodb-largest-documents');
+const mongodbLargestDocuments = require('mongodb-largest-documents');
 
-// Configure task here
-var config = {
-    // MongoDB connection string
-    db: 'localhost/test',
-    // Name of collection to inspect
-    collectionName: 'users',
-    // Process X items every iteration
-    batchSize: 100,
-    // Limit output to X largest documents
-    outputTopXLargest: 100
+const config = {
+    url: 'mongodb://localhost:27017', // MongoDB connection string
+    dbName: 'test',                   // MongoDB Database name
+    collectionName: 'users',          // MongoDB Collection name
+    batchSize: 100,                   // Process X items every iteration
+    outputTopXLargest: 100,           // Limit output to Y largest documents
+    skip: 0,                          // Skip the firsts Z documents
 };
 
-// Run the module
-mongodbLargestDocuments(config, function (err, result) {
-    // Handle errors
-    if (err) {
-        return console.log(err);
-    }
-    
-    // Print largest documents to console
-    console.log('Largest documents:', result);
-});
+function formatOutput (documents) {
+  return documents.map(doc => `- ObjectId("${doc.id}"): ${doc.prettySize} = ${doc.size} Bytes`).join('\n');
+}
+
+mongodbLargestDocuments(config)
+  .then(docs => console.log('Largest documents:\n' + formatOutput(docs)))
+  .catch(err => console.error(err));
+
 ```
 
 Run the script and watch the console for progress - it will invoke your callback when it traverses the entire collection.

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,25 +1,19 @@
 // Change to 'mongodb-largest-documents' to use this code outside of the package
-var mongodbLargestDocuments = require('../');
+const mongodbLargestDocs = require('../');
 
-// Configure task here
-var config = {
-    // MongoDB connection string
-    db: 'localhost/test',
-    // Name of collection to inspect
-    collectionName: 'users',
-    // Process X items every iteration
-    batchSize: 100,
-    // Limit output to X largest documents
-    outputTopXLargest: 100
+const config = {
+    url: 'mongodb://localhost:27017', // MongoDB connection string
+    dbName: 'test',                   // MongoDB Database name
+    collectionName: 'users',          // MongoDB Collection name
+    batchSize: 100,                   // Process X items every iteration
+    outputTopXLargest: 100,           // Limit output to Y largest documents
+    skip: 0,                          // Skip the firsts Z documents
 };
 
-// Run the module
-mongodbLargestDocuments(config, function (err, result) {
-    // Handle errors
-    if (err) {
-        return console.log(err);
-    }
-    
-    // Print largest documents to console
-    console.log('Largest documents:', result);
-});
+function formatOutput (documents) {
+  return documents.map(doc => `- ObjectId("${doc.id}"): ${doc.pretty}`).join('\n');
+}
+
+mongodbLargestDocs(config)
+  .then(docs => console.log('Largest documents:\n' + formatOutput(docs)))
+  .catch(err => console.error(err));

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,9 +11,9 @@ const config = {
 };
 
 function formatOutput (documents) {
-  return documents.map(doc => `- ObjectId("${doc.id}"): ${doc.pretty}`).join('\n');
+  return documents.map(doc => `- ObjectId("${doc.id}"): ${doc.prettySize}`).join('\n');
 }
 
 mongodbLargestDocs(config)
-  .then(docs => console.log('Largest documents:\n' + formatOutput(docs)))
+  .then(docs => console.log('[System]', 'Largest documents:\n' + formatOutput(docs)))
   .catch(err => console.error(err));

--- a/index.js
+++ b/index.js
@@ -1,22 +1,6 @@
-var co = require('co');
-var logic = require('./lib/logic');
+const largest = require('./lib/logic');
 
-module.exports = function(config, callback) {
-    // ES6 generator control flow
-    co(function* () {
-        try {
-            // Log startup
-            console.log('[System]', 'Finding largest documents for collection: ' + config.collectionName);
-            
-            // Find top X largest documents for the given collection
-            var largestDocuments = yield logic.findLargestDocuments(config);
-            
-            // Pass task result to provided callback
-            callback(null, largestDocuments);
-        }
-        catch (err) {
-            // Pass unhandled exception to callback
-            callback(err);
-        }
-    });
+module.exports = function(config) {
+  console.log(`Find largest documents in ${config.db}.${config.collection}`);
+  return largest.findLargestDocuments(config);
 };

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -1,36 +1,44 @@
-var monk = require('monk');
-var bson = require('bson');
-var wrap = require('co-monk');
-var BSON = new bson.BSONPure.BSON();
+const mongo = require('mongodb');
+const MongoClient = mongo.MongoClient;
+const BSON = require('bson-ext');
+const bson = new BSON([BSON.Binary, BSON.Code, BSON.DBRef, BSON.Decimal128, BSON.Double, BSON.Int32, BSON.Long, BSON.Map, BSON.MaxKey, BSON.MinKey, BSON.ObjectId, BSON.BSONRegExp, BSON.Symbol, BSON.Timestamp]);
 
-exports.findLargestDocuments = function* (config) {
+// https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+function formatBytes(a,b){if(0==a)return"0 Bytes";var c=1024,d=b||2,e=["Bytes","KB","MB","GB","TB","PB","EB","ZB","YB"],f=Math.floor(Math.log(a)/Math.log(c));return parseFloat((a/Math.pow(c,f)).toFixed(d))+" "+e[f]}
+
+exports.findLargestDocuments = async function (config) {
     // Initialize DB connection
-    var db = monk(config.db);
-    var collection = wrap(db.get(config.collectionName));
+    const client = await MongoClient.connect(config.url); //, {useNewUrlParser: true});
+    const col = client.db(config.dbName).collection(config.collectionName);
 
-    // Keep track of processed documents for progress log
-    var count = 0;
-    
-    // Array that will contain all documents and their sizes
-    var documents = [];
+    let count = 0; // Keep track of processed documents for progress log
+    let documents = []; // Array that will contain all documents and their sizes
+    let whereClause = {}; // Default query where clause is blank, populate it with last document ID later on
+    let results;
 
-    // Default query where clause is blank, populate it with last document ID later on
-    var whereClause = {};
+    if (config.skip) {
+      doc = await col.findOne(whereClause, {skip: config.skip - 1, sort: {_id: 1}});
+      whereClause._id = { $gt: doc._id };
+      count = config.skip;
+    }
 
-    // Run forever, until no more documents are returned
     while (true) {
         // Get batch of documents
-        var results = yield collection.find(whereClause, { limit: config.batchSize, sort: { _id: 1 } });
-
+        try {
+          results = await col.find(whereClause, {limit: config.batchSize, sort: {_id: 1}}).toArray();
+        } catch (e) {
+          console.error('[System]', `Error fetching ${config.batchSize} documents with clause`, whereClause, `skipping these ${config.batchSize} documents`, e);
+          results = await col.find(whereClause, {limit: config.batchSize, skip: config.batchSize, sort: {_id: 1}}).toArray();
+        }
         // Reached end of collection?
         if (results.length === 0) {
             break;
         }
 
         // Traverse documents
-        for (var doc of results) {
+        for (let doc of results) {
             // Use 'bson' library to calculate document size (in bytes)
-            var size = BSON.calculateObjectSize(doc);
+            let size = bson.calculateObjectSize(doc);
 
             // Add to documents array
             documents.push({ id: doc._id.toString(), size: size });
@@ -41,7 +49,7 @@ exports.findLargestDocuments = function* (config) {
 
         // Log processed documents
         count += results.length;
-            
+
         // Sort the documents array by size DESC
         documents.sort(function (first, second) {
             return second.size - first.size;
@@ -51,9 +59,11 @@ exports.findLargestDocuments = function* (config) {
         documents = documents.slice(0, config.outputTopXLargest);
 
         // Log script progress
-        console.log('[System]', 'Processed ' + count + ' documents');
+        console.log('[System]', `Processed ${count} documents. Highest: ${documents[0].id} => ${formatBytes(documents[0].size)}`);
     }
 
-    // Return result
-    return documents;
+    return documents.map(doc => {
+      doc.pretty = formatBytes(doc.size);
+      return doc;
+    });
 };

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -63,7 +63,7 @@ exports.findLargestDocuments = async function (config) {
     }
 
     return documents.map(doc => {
-      doc.pretty = formatBytes(doc.size);
+      doc.prettySize = formatBytes(doc.size);
       return doc;
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "mongodb-largest-documents",
+  "version": "1.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bson": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
+      "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w=="
+    },
+    "bson-ext": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bson-ext/-/bson-ext-2.0.1.tgz",
+      "integrity": "sha512-neANGYseUnLTZm9ktkngW9k8FJX0erC2OgQi+woqNNQfOMUY7nXOswSJYld3m2+jw3bYs0JC57n8Qt7FID6vqQ==",
+      "requires": {
+        "bindings": "1.3.0",
+        "bson": "2.0.8",
+        "nan": "2.11.0"
+      }
+    },
+    "memory-pager": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
+      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg==",
+      "optional": true
+    },
+    "mongodb": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.6.tgz",
+      "integrity": "sha512-E5QJuXQoMlT7KyCYqNNMfAkhfQD79AT4F8Xd+6x37OX+8BL17GyXyWvfm6wuyx4wnzCCPoCSLeMeUN2S7dU9yw==",
+      "requires": {
+        "mongodb-core": "3.1.5",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "mongodb-core": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.5.tgz",
+      "integrity": "sha512-emT/tM4ZBinqd6RZok+EzDdtN4LjYJIckv71qQVOEFmvXgT5cperZegVmTgox/1cx4XQu6LJ5ZuIwipP/eKdQg==",
+      "requires": {
+        "bson": "1.1.0",
+        "require_optional": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "saslprep": "1.0.2"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
+        }
+      }
+    },
+    "nan": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.5.1"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "saslprep": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
+      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "1.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
   },
   "homepage": "https://github.com/eladnava/mongodb-largest-documents#readme",
   "dependencies": {
-    "bson": "^0.4.23",
-    "co": "^4.6.0",
-    "co-monk": "^1.0.0",
-    "mongoose": "^4.4.15",
-    "monk": "^1.0.1"
+    "bson-ext": "^2.0.1",
+    "mongodb": "^3.1.6"
   }
 }


### PR DESCRIPTION
I had issues with the dependencies, so I updated the code to use the mongoDB nodeJS driver (node-mongodb-native) directly.

I also switched to bson-ext and used `async/await` instead of `co` since node8 has been in LTS for almost a year.